### PR TITLE
Add AI Displacement Tracker to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Price and Volume process with Technology Analysis Indices
 
 #### Alternative Data
 
+- [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset of 95 AI-attributed workforce reduction events (454K workers) across 13 countries. Includes company names, dates, affected worker counts, sectors, and attribution methodology. Useful as alternative economic signal data.
 - [Pizzint](https://www.pizzint.watch/) - Pentagon Pizza Index (PizzINT) is a real-time Pentagon pizza tracker that visualizes unusual activity at Pentagon-area pizzerias. It highlights a signal that has historically aligned with late-night, high-tempo operations and breaking news.
 
 ## Research Tools


### PR DESCRIPTION
## What

Adds the [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the **Alternative Data** section under Data Sources.

## Why

The AI Displacement Tracker is a structured open-data alternative signal for AI's economic impact. It contains 95 verified AI-attributed workforce reduction events affecting 454,000+ workers across 13 countries, with structured fields including company names, dates, affected worker counts, sectors, and attribution methodology.

This dataset is relevant for:

- **Economic modeling**: AI adoption as an alternative signal for labor market shifts and sector-level disruption
- **Workforce analytics**: Quantifying AI's impact on employment across industries and geographies
- **Event-driven strategies**: Tracking corporate AI adoption announcements and their workforce implications as potential market signals

The data is freely available in CSV/JSON format and regularly updated.