### PR TITLE
Add Stock Research Desk to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - 🌟🌟 [nofx](https://github.com/NoFxAiOS/nofx) - A multi-exchange Al trading platform with multi-Ai competition self-evolution, and real-time dashboard.
 - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - Multi-Agents LLM Financial Trading Framework.
 - 🌟 [FinRobot](https://github.com/AI4Finance-Foundation/FinRobot) - An Open-Source AI Agent Platform for Financial Analysis using LLMs.
+- [Stock Research Desk](https://github.com/wd041216-bit/stock-research-desk) - Multi-agent equity research desk for single-name deep dives, theme screening, watchlists, and bilingual memo delivery.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - Decentralized crowdfunding platform for AI agents with milestone-based escrow on Base blockchain.
 - 🌟 [ATLAS](https://github.com/chrisworsey55/atlas-gic) - Self-improving AI trading system with 25 agents, Karpathy-style autoresearch, Darwinian selection, autonomous agent spawning, and multi-cohort meta-weighting.
 - [InvicTrade](https://invictrade.com) - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
@@ -322,4 +323,3 @@ Do it in real world!
 - [FinancePy](https://github.com/domokane/FinancePy) - A Python Finance Library that focuses on the pricing and risk-management of Financial Derivatives, including fixed-income, equity, FX and credit derivatives.
 - [Explore Finance Service Libraries & Projects](https://kandi.openweaver.com/explore/financial-services#Top-Authors) - Explore a curated list of Fintech popular & new libraries, top authors, trending project kits, discussions, tutorials & learning resources on kandi.
 - [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ real energy data records, LangChain/MCP integration.
-


### PR DESCRIPTION
Adds [Stock Research Desk](https://github.com/wd041216-bit/stock-research-desk), a cloud-only multi-agent equity research desk for ticker memos, theme screening, watchlists, and one-DOCX delivery.

Why it fits:
- single-name deep-dive stock research
- theme / sector screening before expensive finalist research
- evidence quality filtering, red-team dissent, scenario branches, and target prices with time horizons
- mailbox-friendly watchlist refreshes and a Codex skill mode
- final human-facing output is one desktop DOCX, while JSON / memory state stays internal

Latest public references:
- [Project Showcase](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/showcase.md)
- [Sample Research Memo](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-memo.md)
- [Sample Screening Summary](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-screening.md)
- [CLI Workflow](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/cli-workflow.md)
