### PR TITLE
Add SignalFuse to Crypto Currencies trading systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ For Back Test & Live trading
 - [QuantResearchDev](https://github.com/mounirlabaied/QuantResearchDev) - Quant Research dev & Traders open source project.
 - [MACD](https://github.com/sudoscripter/MACD) - Zenbot MACD Auto-Trader.
 - [abu](https://github.com/bbfamily/abu) - A quant trading system base on python.
-- [SignalFuse](https://github.com/cferjo/signalfuse-starter-bot) - AI-powered crypto trading signal engine using contextual bandits (UCB) for autonomous strategy selection. Fuses social sentiment, macro regime, and market structure signals to trade Hyperliquid perpetuals.
+- [SignalFuse](https://github.com/hypeprinter007-stack/signalfuse-starter-bot) - AI-powered crypto trading signal engine using contextual bandits (UCB) for autonomous strategy selection. Fuses social sentiment, macro regime, and market structure signals to trade Hyperliquid perpetuals.
 
 #### Plugins
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ For Back Test & Live trading
 - [QuantResearchDev](https://github.com/mounirlabaied/QuantResearchDev) - Quant Research dev & Traders open source project.
 - [MACD](https://github.com/sudoscripter/MACD) - Zenbot MACD Auto-Trader.
 - [abu](https://github.com/bbfamily/abu) - A quant trading system base on python.
+- [SignalFuse](https://github.com/cferjo/signalfuse-starter-bot) - AI-powered crypto trading signal engine using contextual bandits (UCB) for autonomous strategy selection. Fuses social sentiment, macro regime, and market structure signals to trade Hyperliquid perpetuals.
 
 #### Plugins
 


### PR DESCRIPTION
## Summary

- Adds [SignalFuse](https://github.com/cferjo/signalfuse-starter-bot) to the **Trading System > Crypto Currencies** section
- SignalFuse is an open-source AI-powered crypto trading signal engine that uses contextual bandits (UCB) for autonomous strategy selection, fusing social sentiment, macro regime, and market structure signals to trade Hyperliquid perpetuals
- Website: https://signalfuse.co

## Checklist

- [x] Entry follows existing list format (`- [Name](url) - Description.`)
- [x] Placed in the appropriate section (Crypto Currencies under Trading System)
- [x] Project is open source
- [x] Description is concise and accurate