### PR TITLE
Add FinanceKit MCP to Data Sources > Traditional Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Price and Volume process with Technology Analysis Indices
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [StockAInsights](https://stockainsights.com) - Institutional-grade financial statements API with AI extraction from SEC filings — not XBRL. Covers domestic and foreign filers (20-F, 6-K, 40-F), normalized quarterly and annual data.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
+- [FinanceKit MCP](https://github.com/vdalhambra/financekit-mcp) - MCP server with 17 tools for AI agents: real-time stock quotes, technical analysis (RSI, MACD, Bollinger, ADX, Stochastic + Golden/Death Cross detection with structured verdicts), crypto via CoinGecko, risk metrics (VaR, Sharpe, Sortino, Beta), correlation matrix, options chains, earnings calendar, sector rotation, portfolio analysis. No API keys. Works with Claude Desktop, Cursor, Windsurf.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
Hi! Per your request on #110, opening this PR to add FinanceKit MCP to Data Sources > Traditional Markets.

**FinanceKit MCP** — https://github.com/vdalhambra/financekit-mcp

17 tools for AI agents:
- Real-time stock quotes (Yahoo Finance, no API key)
- Technical analysis: RSI, MACD, Bollinger, SMA/EMA, ADX, Stochastic, ATR, OBV + Golden/Death Cross detection with plain-English verdicts
- Crypto via CoinGecko (free, no API key)
- Risk metrics: VaR, Sharpe, Sortino, Beta, Max Drawdown
- Correlation matrix, options chains, earnings calendar, sector rotation, portfolio analysis

**Different from a Yahoo wrapper:** returns structured verdicts ("STRONGLY BULLISH with 3.0 signals"), designed for LLM consumption.

Live on: PyPI, MCPize, Smithery, Glama, Official MCP Registry (`io.github.vdalhambra/financekit-mcp`).

FastMCP 3.2, MIT. Works in Claude Desktop, Cursor, Windsurf, Claude Code.

Closes #110.