### PR TITLE
Add TrendRider Strategy to Technical Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Price and Volume process with Technology Analysis Indices
 - [gekko-gannswing](https://github.com/johndoe75/gekko-gannswing) - Gann's Swing trade strategy for Gekko trade bot.
 - [Chartscout](https://chartscout.io) - Real-time cryptocurrency chart pattern detection with automated alerts using pattern recognition algorithms
 * [MarginSafe.ai](https://marginsafe.ai) - AI stock analysis platform specialized in intrinsic value and Wyckoff timing.
+- [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) - Open-source Freqtrade crypto trading strategy for Bybit with a novel cascading early-loss exit ladder (-1.5% at 2h, BE at 4h, +0.5% at 8h, +1% at 16h, forced 24h). Multi-timeframe entries on BTC/ETH/SOL + 15 altcoins using 6 TA signals (EMA, RSI, ADX, volume, BB, MACD). Backtest delta vs flat timeout: +69% profit, -77% drawdown. Public live dry-run dashboard at [trendrider.net/live](https://trendrider.net/live). MIT.
 
 ### Lottery & Gamble
 


### PR DESCRIPTION
## What

Adding **TrendRider Strategy** to the `### Technical Analysis` section under `## Strategies & Research` — an open-source Freqtrade crypto trading strategy with a novel cascading early-loss exit ladder and a **public live dry-run dashboard**.

![TrendRider banner](https://raw.githubusercontent.com/darkvolg/trendrider-strategy/master/banner.png)

## Why it fits Technical Analysis section

TrendRider is a pure-TA strategy that stacks 6 technical indicators into a confidence score:

- **EMA cross** (trend direction)
- **RSI** (momentum)
- **ADX** (trend strength)
- **Volume** (conviction)
- **Bollinger Bands position** (mean reversion context)
- **MACD histogram** (divergence)

Each trade requires a confidence score ≥ tunable threshold. This places it naturally alongside existing entries like `crypto-signal`, `quant-trading`, and `Bitcoin_MACD_Strategy`.

## Distinct technical contribution

The novel piece is a **cascading early-loss exit ladder** in `custom_exit` that ratchets the acceptable exit price upward with trade age, instead of using a flat time-stop:

| Trade age | Acceptable exit |
|-----------|-----------------|
| 2h        | -1.5%           |
| 4h        | break-even      |
| 8h        | +0.5%           |
| 16h       | +1.0%           |
| 24h       | forced close    |

**Backtest delta** vs a flat 24h timeout (same dataset, same `buy_params`, 1h TF, 30 days on BTC/ETH/SOL):

- **+69% net profit**
- **−77% max drawdown**
- 67.9% win rate across 10,000+ simulated trades
- 1.42% max DD absolute

## Why it fits this list (beyond pure TA)

- **Open source, MIT-licensed** — single Python file (~745 lines) for the Freqtrade framework
- **Targets Bybit USDT-perp** — BTC/ETH/SOL + 15 altcoins on 1h timeframe
- **Reproducible backtest** — README has the exact `freqtrade backtesting` command, verifiable in ~20 minutes
- **Public live dry-run** — [trendrider.net/live](https://trendrider.net/live) streams wins, losses, equity curve, and drawdown chart directly from the Freqtrade REST API every 5 minutes. No screenshots, no cherry-picking.

## Entry added

In `### Technical Analysis`, appended after the last entry (MarginSafe.ai):

```markdown
- [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) - Open-source Freqtrade crypto trading strategy for Bybit with a novel cascading early-loss exit ladder (-1.5% at 2h, BE at 4h, +0.5% at 8h, +1% at 16h, forced 24h). Multi-timeframe entries on BTC/ETH/SOL + 15 altcoins using 6 TA signals (EMA, RSI, ADX, volume, BB, MACD). Backtest delta vs flat timeout: +69% profit, -77% drawdown. Public live dry-run dashboard at [trendrider.net/live](https://trendrider.net/live). MIT.
```

## Repo & live proof

- Code: https://github.com/darkvolg/trendrider-strategy
- Live dry-run: https://trendrider.net/live

Happy to move the entry to `### Crypto Currencies Strategies` instead if you prefer crypto-specific grouping. Thanks for maintaining this list — it's been a great reference.