### PR TITLE
Add Helium MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [InvicTrade](https://invictrade.com) - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - AI-native one-person hedge fund platform. Expert agent teams turn natural language into quant strategies in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline with community leaderboard.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server providing AI bull/bear cases, ML options pricing, and balanced news synthesis for financial intelligence.
 
 ## LLMs
 


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp): a remote MCP server for market intelligence, ML options pricing, and news bias analysis across 5,000+ sources. Free tier with no API key required.

Documentation: https://heliumtrades.com/mcp