### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Price and Volume process with Technology Analysis Indices
 
 #### Alternative Data
 
+- [Adanos Market Sentiment API](https://api.adanos.org/docs/) - Market sentiment API for AI finance agents covering stocks across Reddit, X/Twitter, news, and Polymarket prediction markets with buzz, sentiment, trending, and comparison signals.
 - [Pizzint](https://www.pizzint.watch/) - Pentagon Pizza Index (PizzINT) is a real-time Pentagon pizza tracker that visualizes unusual activity at Pentagon-area pizzerias. It highlights a signal that has historically aligned with late-night, high-tempo operations and breaking news.
 
 #### Prediction Markets
@@ -325,4 +326,3 @@ Do it in real world!
 - [FinancePy](https://github.com/domokane/FinancePy) - A Python Finance Library that focuses on the pricing and risk-management of Financial Derivatives, including fixed-income, equity, FX and credit derivatives.
 - [Explore Finance Service Libraries & Projects](https://kandi.openweaver.com/explore/financial-services#Top-Authors) - Explore a curated list of Fintech popular & new libraries, top authors, trending project kits, discussions, tutorials & learning resources on kandi.
 - [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ real energy data records, LangChain/MCP integration.
-


### PR DESCRIPTION
## Summary

Adds Adanos Market Sentiment API to the `Data Sources -> Alternative Data` section.

This fits the list as an AI-finance data source for market sentiment signals across Reddit, X/Twitter, news, and Polymarket prediction markets.

## Validation

- `git diff --check`
- Verified the README entry is present once under `Alternative Data`
- Verified `https://api.adanos.org/docs/` returns HTTP 200 after redirects