### PR TITLE
Add cipher-layer-k (Solana autonomous trading module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ For Back Test & Live trading
 - [QuantResearchDev](https://github.com/mounirlabaied/QuantResearchDev) - Quant Research dev & Traders open source project.
 - [MACD](https://github.com/sudoscripter/MACD) - Zenbot MACD Auto-Trader.
 - [abu](https://github.com/bbfamily/abu) - A quant trading system base on python.
+- [cipher-layer-k](https://github.com/cryptomotifs/cipher-layer-k) - Solana autonomous trading module in Python: 8-category confirmation matrix, IC-weighted ensemble, eighth-Kelly sizing, staged rollout, circuit breaker. MIT. 48 tests green.
 
 #### Plugins
 


### PR DESCRIPTION
Adding [cipher-layer-k](https://github.com/cryptomotifs/cipher-layer-k) to **Trading System › Crypto Currencies**.

It's a Python 3.11+ autonomous trading module for Solana: 8-category confirmation matrix, IC-weighted ensemble scoring, eighth-Kelly position sizing, staged rollout (1%→10%→100%), and a circuit breaker + kill switch. MIT-licensed, 48 tests passing.

Happy to move to a different section (e.g. Strategies & Research › Crypto Currencies Strategies) or shorten the description if you prefer.