### PR TITLE
Add MeterCall (data-flex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,3 +326,4 @@ Do it in real world!
 - [Explore Finance Service Libraries & Projects](https://kandi.openweaver.com/explore/financial-services#Top-Authors) - Explore a curated list of Fintech popular & new libraries, top authors, trending project kits, discussions, tutorials & learning resources on kandi.
 - [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ real energy data records, LangChain/MCP integration.
 
+- [MeterCall](https://metercall.ai/?v=f&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** 21 million APIs at one URL. Payments, SMS, AI, CRMs, gov, crypto — all metered.
- **URL:** https://metercall.ai/?v=f&src=github
- **Why it belongs here:** 🔬 A curated list of awesome LLMs & deep learning strategies & tools in financial market.

Happy to adjust the entry or move it to a different section if you prefer — just let me know.