### PR TITLE
Add BitBank.nz to Crypto Currencies Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Price and Volume process with Technology Analysis Indices
 
 #### Crypto Currencies
 
+- [BitBank.nz](https://bitbank.nz) - AI-powered crypto forecasting and predictions API with machine learning models for 70+ cryptocurrency pairs.
 - [CryptoInscriber](https://github.com/Optixal/CryptoInscriber) - A live crypto currency historical trade data blotter. Download live historical trade data from any crypto exchange.
 - [CoinPulse](https://github.com/soutone/coinpulse-python) - Python SDK for cryptocurrency portfolio tracking with real-time prices, P/L calculations, backtesting, and price alerts. Free tier: 25 req/hr.
 - [Gekko-Datasets](https://github.com/xFFFFF/Gekko-Datasets) - Gekko trading bot dataset dumps. Download and use history files in SQLite format.


### PR DESCRIPTION
## Summary
- Add [BitBank.nz](https://bitbank.nz) to the **Data Sources > Crypto Currencies** section

## Details
BitBank.nz is an AI-powered crypto forecasting and predictions API that uses machine learning models (including Chronos2 transformers) to provide real-time predictions for 70+ cryptocurrency pairs. It offers hourly forecasts with 7-hour and 7-day predictions, confidence scoring, and transparent accuracy tracking.

The entry follows the existing list format and is inserted in alphabetical order.