### PR TITLE
Add BenchGecko to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Price and Volume process with Technology Analysis Indices
 - [FXMacroData](https://fxmacrodata.com) - Macroeconomic and FX data API with central bank announcements, policy rates, inflation, employment, GDP, release calendars, and MCP access for 18 currencies.
 - [StockAInsights](https://stockainsights.com) - Institutional-grade financial statements API with AI extraction from SEC filings — not XBRL. Covers domestic and foreign filers (20-F, 6-K, 40-F), normalized quarterly and annual data.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
+- [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
Adds BenchGecko as an AI economy data source.

BenchGecko tracks the financial landscape of the AI industry including company valuations, funding rounds, market concentration (HHI), and the AI Bubble Index.

https://benchgecko.ai/economy