### PR TITLE
Add 13F Insight to Traditional Markets data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Price and Volume process with Technology Analysis Indices
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [FXMacroData](https://fxmacrodata.com) - Macroeconomic and FX data API with central bank announcements, policy rates, inflation, employment, GDP, release calendars, and MCP access for 18 currencies.
 - [StockAInsights](https://stockainsights.com) - Institutional-grade financial statements API with AI extraction from SEC filings — not XBRL. Covers domestic and foreign filers (20-F, 6-K, 40-F), normalized quarterly and annual data.
+- [13F Insight](https://13finsight.com) - AI-powered 13F SEC filing tracker. Monitor hedge fund and institutional investor portfolio changes, with smart money move alerts and historical holding comparisons.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 
 #### Crypto Currencies


### PR DESCRIPTION
## What

Add [13F Insight](https://13finsight.com) to the **Traditional Markets** section under **Data Sources**.

```
- [13F Insight](https://13finsight.com) - AI-powered 13F SEC filing tracker. Monitor hedge fund and institutional investor portfolio changes, with smart money move alerts and historical holding comparisons.
```

## Why

- **Directly relevant**: 13F filings are the primary source for institutional / smart-money position data in traditional US equity markets — a natural complement to StockAInsights and Congressional Stock Brain already listed here.
- **AI-powered**: Uses LLMs to summarize filing changes and surface signals, consistent with this list's focus on AI × finance.
- **Free tier available**: Freemium product, accessible to researchers and quant practitioners.

## Placement

Inserted after StockAInsights (also SEC-filing focused), before ValueRay.