### PR TITLE
Add Vibe-Trading to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - 🌟 [ATLAS](https://github.com/chrisworsey55/atlas-gic) - Self-improving AI trading system with 25 agents, Karpathy-style autoresearch, Darwinian selection, autonomous agent spawning, and multi-cohort meta-weighting.
 - [InvicTrade](https://invictrade.com) - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - AI-native one-person hedge fund platform. Expert agent teams turn natural language into quant strategies in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline with community leaderboard.
+- [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) - AI-powered multi-agent finance research workspace that turns natural language into trading strategies, cross-market backtests, portfolio analysis, and research insights.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
 
 ## LLMs


### PR DESCRIPTION
## Summary
- Add HKUDS/Vibe-Trading to the Agents section.
- Describe it as a multi-agent finance research workspace for natural-language strategy generation, cross-market backtests, portfolio analysis, and research insights.

## Validation
- Ran `git diff --check`.