### PR TITLE
Add VC Deal Flow Signal under Alternative Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Price and Volume process with Technology Analysis Indices
 
 - [Adanos Market Sentiment API](https://api.adanos.org/docs/) - Market sentiment API for AI finance agents covering stocks across Reddit, X/Twitter, news, and Polymarket prediction markets with buzz, sentiment, trending, and comparison signals.
 - [Pizzint](https://www.pizzint.watch/) - Pentagon Pizza Index (PizzINT) is a real-time Pentagon pizza tracker that visualizes unusual activity at Pentagon-area pizzerias. It highlights a signal that has historically aligned with late-night, high-tempo operations and breaking news.
+- [VC Deal Flow Signal](https://huggingface.co/datasets/the-data-nerd/vc-deal-flow-signal) - Open longitudinal panel of GitHub-derived engineering-velocity signals (14-day commit cadence, contributor growth, signal-type classification) across venture-backed startups, designed for VC deal flow research and alternative-data ML. 309 rows across three configs, CC BY 4.0, DOI 10.5281/zenodo.19650920.
 
 #### Prediction Markets
 


### PR DESCRIPTION
### Why this fits Alternative Data

Adds **VC Deal Flow Signal** — an open longitudinal panel of GitHub-derived engineering-velocity signals for venture-backed startups. Combines public commit cadence, contributor growth, repository-creation events, and inferred signal types (framework migration, engineering hiring burst, infrastructure buildout, deploy frequency spike) into a normalized panel for venture-capital deal-flow analysis and alternative-data machine learning.

- **Open / no login**: hosted on Hugging Face Datasets, downloadable directly.
- **Open license**: CC BY 4.0.
- **Scale**: 309 rows across three configs (`startup_signals`, `sector_aggregates`, `signal_type_timeseries`); monthly accrual; 2024-01 → 2026-04 coverage.
- **Reproducibility**: persistent DOI `10.5281/zenodo.19650920`, companion working paper on SSRN (`abstract=6606558`), ORCID `0009-0002-2222-4112`.
- **Cross-listed**: Zenodo, Kaggle, Data.world, plus a live JSON/CSV API at `signals.gitdealflow.com`.

### Files
- `README.md` — single-line addition under `#### Alternative Data`.