### PR TITLE
Add oracle3 to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [InvicTrade](https://invictrade.com) - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - AI-native one-person hedge fund platform. Expert agent teams turn natural language into quant strategies in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline with community leaderboard.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
+- [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Autonomous trading agent for Kalshi, Polymarket, and Solana DFlow with Wang Transform pricing (calibrated on 291k resolved contracts, λ̂ = 0.183), eight constraint-based arbitrage strategies, hierarchical MLE, and Kelly-sized execution. Apache 2.0; methodology in companion SSRN working paper.
 
 ## LLMs
 


### PR DESCRIPTION
Adding [oracle3](https://github.com/YichengYang-Ethan/oracle3) to the **Agents** section.

oracle3 is an autonomous AI-driven trading agent operating across Kalshi, Polymarket, and Solana DFlow prediction markets. It uses the Wang Transform pricing model (calibrated on 291,309 resolved contracts) as a fair-value engine, then runs eight constraint-based arbitrage strategies plus Kelly-sized model trades. Complements existing entries (TradingAgents, FinRobot, ATLAS, ProfitPlay) with a prediction-market-specific pricing layer.

**Working paper**: [Pricing Prediction Markets: Risk Premiums, Incomplete Markets, and a Decomposition Framework](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338) (Yang, 2026, UIUC)

### Quality
- License: Apache 2.0
- Activity: v1.1.0 released 2026-05-07
- Tests: 633 passing, mypy + ruff + codespell on every push
- Stars: 170+
- Documentation: full [docs site](https://yichengyang-ethan.github.io/oracle3)