### PR TITLE
Add Awesome AI Startups to Other Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,4 @@ Do it in real world!
 - [Explore Finance Service Libraries & Projects](https://kandi.openweaver.com/explore/financial-services#Top-Authors) - Explore a curated list of Fintech popular & new libraries, top authors, trending project kits, discussions, tutorials & learning resources on kandi.
 - [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ real energy data records, LangChain/MCP integration.
 - [MeterCall](https://metercall.ai/?v=f&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.
+- [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) — A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the `Other Resource` subsection under `Others`, where this list already cross-references other curated/awesome lists.

**About the list:** A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders. ~440 entries across 18 categories (productivity, design, dev tools, finance, etc.), focused on indie/solo-founder AI products rather than venture-backed startups.

**Format:** Single bullet, matches the style of neighboring entries in the same subsection (em dash separator, concise objective description).