### PR TITLE
Add FilingFirehose (SEC EDGAR + MCP) to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Price and Volume process with Technology Analysis Indices
 - [13F Insight](https://13finsight.com) - AI-powered 13F SEC filing tracker. Monitor hedge fund and institutional investor portfolio changes, with smart money move alerts and historical holding comparisons.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
+- [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with body-text-classified 8-Ks (flags items the filer didn't report — 7.3% of recent Item 8.01 filings have buried 1.05/5.02/etc. events), Schedule 13D/G with 21+ activist filers auto-tagged (Saba/Bulldog/Icahn/Elliott/Starboard/etc.), S-3/424B5 ATM offering detection. Hosted MCP server at `https://filingfirehose.com/mcp`. Also exposed as ChatGPT GPT, Python SDK, GitHub Action. Free public tier (last 72h), paid tier $29-$299/mo or $999 lifetime.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
Adds FilingFirehose, an SEC EDGAR JSON API with body-text classification of 8-Ks. The wedge is that we re-classify each 8-K from body text and flag items the filer didn't report — 7.3% of recent Item 8.01 filings have buried 1.05 (cyber) or 5.02 (officer departure) events.

Particularly relevant for the AI-in-finance audience because we ship as a hosted MCP server (`https://filingfirehose.com/mcp`) — Claude Desktop / Cursor / Windsurf users can install with one config line. Also a ChatGPT custom GPT and Python SDK.

Free public tier (no auth, past 72h). Paid from $29/mo.

Site: https://filingfirehose.com
Research: https://filingfirehose.com/research/buried-events