### PR TITLE
Add: AI Agent Accountability Standard — open standard for agent task accountability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [Others](#others)
 
 ## Agents
+- [AI Agent Accountability Standard](https://github.com/addvalueorbesubtracted/ai-agent-accountability-standard) - Open standard for AI agent task accountability in financial & enterprise contexts. Defines task schemas, evidence requirements, graduated slashing rubrics, and identity tiers (T1–T6) for on-chain Performance Bonds. IPFS-pinned, MIT licensed.
 
 - 🌟🌟 [nofx](https://github.com/NoFxAiOS/nofx) - A multi-exchange Al trading platform with multi-Ai competition self-evolution, and real-time dashboard.
 - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - Multi-Agents LLM Financial Trading Framework.


### PR DESCRIPTION
Adds the [AI Agent Accountability Standard](https://github.com/addvalueorbesubtracted/ai-agent-accountability-standard), an open spec particularly relevant to financial services AI agent deployments.

Defines:
- Task schemas for common agent task types
- Evidence requirements for reasoning logs
- Graduated slashing rubrics (0–100%)
- Identity tiers T1–T6 (including financial task authorization)
- Multi-oracle quorum requirements for bonds >$500

IPFS-pinned (CID: `QmQUbRzc5VCPND8aK14bs8oYGozdWggnF7xK5r8DMUtYzL`), MIT licensed.