### PR TITLE
Add AI Models Catalog to Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Price and Volume process with Technology Analysis Indices
 - [CRNG](https://github.com/brotto/crng) - Contingency RNG, generates random numbers with real market fat tails (K=5-220) and volatility clustering. Matches 86% of real market metrics vs 14% for NumPy. Includes regime detector.
 - [Chart Library](https://chartlibrary.io) - Visual chart pattern search engine. Upload a screenshot or type a ticker+date to find the 10 most similar historical chart patterns and see what happened next. 24M+ embeddings, 19K symbols, REST API + MCP server.
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action & volume spikes dashboard for crypto traders. Free, no sign-up required.
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured YAML catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Compare LLM costs for financial applications.
 
 ## Trading System
 


### PR DESCRIPTION
Hi! I'd like to add the [AI Models Catalog](https://github.com/i-need-token/ai-models) to the Research Tools section.

**What it is:** A structured YAML catalog of 4,587+ AI models across 95 providers, with first-party data on pricing, context windows, modalities, and capabilities.

**Why it's useful for finance practitioners:** When building financial AI applications, choosing the right LLM matters for both cost and capability. The catalog lets you:
- Compare model pricing (e.g., GPT-4o at $2.50/$10 vs DeepSeek at $0.14/$0.28 per 1M tokens)
- Find models with structured output for parsing financial data
- Filter by context window for long document analysis (earnings reports, SEC filings)
- Use the [interactive pricing calculator](https://i-need-token.github.io/ai-models/ai-model-pricing-calculator.html) to estimate monthly costs

All data sourced from first-party APIs, validated with Zod schemas, updated automatically via CI.

Thanks for considering!