### PR TITLE
Add Tapetide to Data Sources (Traditional Markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Price and Volume process with Technology Analysis Indices
 - [Tushare](https://github.com/waditu/tushare) - TuShare is a utility for crawling historical data of China stocks.
 - [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered tool that scores U.S. STOCK Act congressional trade disclosures by significance. Committee weighting, timing analysis, 537 members tracked.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
+- [Tapetide](https://tapetide.com) - AI-first stock research API and MCP server for Indian markets (NSE & BSE). Covers all 8,200+ listed stocks with quotes, financials, a 326-ratio screener, and FII/DII institutional flows. Free tier, MCP access for AI agents.
 - [FXMacroData](https://fxmacrodata.com) - Macroeconomic and FX data API with central bank announcements, policy rates, inflation, employment, GDP, release calendars, and MCP access for 18 currencies.
 - [StockAInsights](https://stockainsights.com) - Institutional-grade financial statements API with AI extraction from SEC filings — not XBRL. Covers domestic and foreign filers (20-F, 6-K, 40-F), normalized quarterly and annual data.
 - [13F Insight](https://13finsight.com) - AI-powered 13F SEC filing tracker. Monitor hedge fund and institutional investor portfolio changes, with smart money move alerts and historical holding comparisons.


### PR DESCRIPTION
Adds **Tapetide** to **Data Sources → Traditional Markets**, alongside other market-data APIs like Financial Data and ValueRay.

`- [Tapetide](https://tapetide.com) - AI-first stock research API and MCP server for Indian markets (NSE & BSE). Covers all 8,200+ listed stocks with quotes, financials, a 326-ratio screener, and FII/DII institutional flows. Free tier, MCP access for AI agents.`

Tapetide is an India-focused market-data source (NSE & BSE) with a public API and MCP server for AI agents — complements the existing China (TuShare) and US sources. Follows the existing one-line format. No duplicate.