### PR TITLE
Add TWZRD Agent Intel: on-chain trust MCP server for AI agents handling Solana payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) - Multi-agent finance research workspace for strategy generation, backtests, portfolio analysis, and research insights.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
 - [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Prediction-market trading agent for Kalshi, Polymarket, and Solana DFlow, with Wang Transform pricing and arbitrage strategies.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust infrastructure MCP server for AI agents handling Solana payments. Provides `score_agent`, `preflight_check`, and `verify_trust_receipt` (free) plus `get_trust_receipt` (signed V5 receipt, paid via x402 USDC micropayment). Designed for agents that need to verify counterpart reputation before executing financial transactions.
 
 ## LLMs
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents operating with Solana payments.

AI agents call \`preflight_check\` before dispatching transactions, \`score_agent\` to query trust scores, and \`get_trust_receipt\` to mint a signed V5 receipt (paid via x402 USDC micropayment, <1s Solana settlement).

Zero-install: \`{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}\`

Added to the **Agents** section as TWZRD Agent Intel is trust infrastructure for AI financial/crypto agents: it provides the reputation layer that lets agents safely execute financial transactions against unknown counterparts, making it a direct complement to trading agents and Solana DeFi agents already listed in this section.