### PR TITLE
feat: The Stall — 210 pay-per-call AI capabilities via x402 (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Price and Volume process with Technology Analysis Indices
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 - [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with classified 8-Ks, activist 13D/G tagging, ATM offering detection, and hosted MCP access.
+- [The Stall](https://github.com/thebrierfox/the-stall) - Pay-per-call MCP server with 173 financial market data capabilities: US stocks, ETFs, equity fundamentals, analyst ratings, earnings surprises, insider trades, hedge fund holdings, options chains, treasury yields, macro indicators, DeFi, crypto, and prediction markets. No API keys required; pay in USDC on Base via x402.
 
 #### Crypto Currencies
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Price and Volume process with Technology Analysis Indices
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 - [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with classified 8-Ks, activist 13D/G tagging, ATM offering detection, and hosted MCP access.
-- [The Stall](https://github.com/thebrierfox/the-stall) - Pay-per-call MCP server with 173 financial market data capabilities: US stocks, ETFs, equity fundamentals, analyst ratings, earnings surprises, insider trades, hedge fund holdings, options chains, treasury yields, macro indicators, DeFi, crypto, and prediction markets. No API keys required; pay in USDC on Base via x402.
+- [The Stall](https://github.com/thebrierfox/the-stall) - Pay-per-call MCP server with 178 financial market data capabilities: US stocks, ETFs, equity fundamentals, analyst ratings, earnings surprises, insider trades, hedge fund holdings, options chains, treasury yields, macro indicators, DeFi, crypto, and prediction markets. No API keys required; pay in USDC on Base via x402.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and 185+ more.

**New in v4.64.0:**
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal, from EDGAR)
- `cron-parser` — parse and explain cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: d25c40a | version: v4.64.0 | caps: 210