### PR TITLE
Add Melaya under Agents — 7-persona AI trading crew with HITL approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
 - [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Prediction-market trading agent for Kalshi, Polymarket, and Solana DFlow, with Wang Transform pricing and arbitrage strategies.
 
+- [Melaya](https://melaya.org) - Hosted agentic trading platform with a 7-persona AI trading crew (Macro, TA, Quant, Sentiment, Risk, Portfolio, Execution) plus 4 sidecar watchers. HITL approval on every order. Bring any of 20+ AI providers per persona. Wired to an in-house Rust trading engine at 420 ns per bar across 65 CEX and 6 prediction markets. Dry-run mode end to end on live market data before flipping any live key.
 ## LLMs
 
 - 🌟🌟🌟 [Nof1](https://thenof1.com/) - Benchmark designed to measure AI's investing abilities. Each model is given $10,000 of real money, in real markets, with identical prompts and input data.


### PR DESCRIPTION
Submitting **Melaya** for the Agents section, alongside FinRobot, TradingAgents, and OpenFinClaw.

Melaya's flagship is a 7-persona AI trading crew (Macro, TA, Quant, Sentiment, Risk, Portfolio, Execution) plus 4 sidecar watchers (Drawdown Sentinel, Macro Blackout, Funding Flip, Liquidation Cascade). Risk holds veto. Every order pauses for human approval. Each persona picks its model independently across 20+ AI providers (Claude, GPT, Gemini, Mistral, DeepSeek, Ollama, LM Studio, ...). Runs end to end in dry-run mode on live market data before any live key flips on.

Wired to a Rust trading engine at 420 ns per bar across 65 CEX and 6 prediction markets (Polymarket, Kalshi, Drift, SX Bet, Azuro, Overtime). Source SDKs in 9 languages. Open benchmarks at https://melaya.org/benchmarks.

Inserted alphabetically under `## Agents` matching the existing one-line bullet format used by FinRobot / TradingAgents.