### PR TITLE
Add MMESGBench (multimodal ESG document benchmark) to LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [Hands-on LLMs: Train and Deploy a Real-time Financial Advisor](https://github.com/iusztinpaul/hands-on-llms) - Train and deploy a real-time financial advisor chatbot with Falcon 7B and CometLLM.
 - [ChatGPT Strategy by OctoBot](https://blog.octobot.online/trading-using-chat-gpt) - Use ChatGPT to determine which cryptocurrency to trade based on technical indicators.
 - [LLMs Meet Finance](https://arxiv.org/abs/2504.13125) - A three-stage fine-tuning pipeline (SFT → DPO → synthetic-data RL) that adapts Qwen2.5 and DeepSeek-R1 to financial tasks on the Open FinLLM Leaderboard, with findings on cross-task transfer and data scaling laws in finance.
+- [MMESGBench](https://github.com/Zhanglei1103/MMESGBench) - First multimodal benchmark for understanding and complex reasoning over real-world ESG reports; 933 expert-validated QA pairs across 45 documents with text/table/chart evidence and single-page, cross-page, and unanswerable questions (ACM MM 2025).
 
 ## Skills
 


### PR DESCRIPTION
Adds **MMESGBench** to the **LLMs** section, alongside the existing FinLLM benchmarks (PIXIU, FinRpt).

First **multimodal** benchmark for understanding and complex reasoning over real-world **ESG reports** — increasingly relevant to sustainable finance / responsible investing: 933 expert-validated QA pairs across 45 documents, with text/table/chart evidence and single-page / cross-page / unanswerable questions.

- Paper: https://arxiv.org/abs/2507.18932 (ACM MM 2025)
- Code/Dataset: https://github.com/Zhanglei1103/MMESGBench

Follows the `- [Name](url) - Description.` format.