### PR TITLE
Add EDGAR Events to Data Sources (Traditional Markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Price and Volume process with Technology Analysis Indices
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 - [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with classified 8-Ks, activist 13D/G tagging, ATM offering detection, and hosted MCP access.
+- [EDGAR Events](https://edgarevents.com) - SEC EDGAR filings as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist and passive stakes resolved to holder/target/percent, S-1/424B IPOs, merger proxies (425/DEFM14A), and HMAC-signed webhooks. Free tier and $29/mo.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
Adds EDGAR Events to Data Sources -> Traditional Markets, next to the SEC-filings APIs already listed (FilingFirehose, 13F Insight, StockAInsights).

EDGAR Events turns SEC EDGAR filings into typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist and passive stakes resolved to holder/target/percent, S-1/424B IPO forms, merger proxies (425/DEFM14A), and HMAC-signed webhooks. Free tier plus a $29/mo plan. OpenAPI at https://api.edgarevents.com/openapi.json.

Independent service, not affiliated with the SEC.