### PR TITLE
Add Wickra to Technical Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Price and Volume process with Technology Analysis Indices
 - [gekko-gannswing](https://github.com/johndoe75/gekko-gannswing) - Gann's Swing trade strategy for Gekko trade bot.
 - [Chartscout](https://chartscout.io) - Real-time cryptocurrency chart pattern detection with automated alerts using pattern recognition algorithms
 * [MarginSafe.ai](https://marginsafe.ai) - AI stock analysis platform specialized in intrinsic value and Wyckoff timing.
+- [Wickra](https://github.com/wickra-lib/wickra) - Native library computing 500+ technical-analysis indicators over OHLC data, streaming-first; Rust core with Python, Node.js, WASM and a C ABI (C/C++/C#/Go/Java/R) bindings.
 
 ### Lottery & Gamble
 


### PR DESCRIPTION
Adds **Wickra** to the **Technical Analysis** section.

A native library that computes 500+ technical-analysis indicators over OHLC data, streaming-first (same code path for backtesting and live ticks). Rust core with Python, Node.js, WASM and a C ABI exposing C / C++ / C# / Go / Java / R bindings. Open source (MIT OR Apache-2.0).

Fits alongside existing entries like `forex.analytics` (a native TA library over OHLC). Appended to the end of the section, dash-bullet format.

- Repo: https://github.com/wickra-lib/wickra
- Docs: https://docs.wickra.org