### PR TITLE
Add stock-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) - Multi-agent finance research workspace for strategy generation, backtests, portfolio analysis, and research insights.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
 - [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Prediction-market trading agent for Kalshi, Polymarket, and Solana DFlow, with Wang Transform pricing and arbitrage strategies.
+- [stock-analysis](https://github.com/AdvancingTitans/stock-analysis) - Evidence-driven market recap CLI for AI agents, producing Markdown reports and JSON Evidence Packs for A/HK/US stocks, funds, and portfolios.
 
 ## LLMs
 


### PR DESCRIPTION
## Summary

Adds stock-analysis to the Agents section.

## Why it fits

- stock-analysis is an open-source market recap CLI designed for AI-agent workflows.
- It produces Markdown reports plus JSON Evidence Packs for A/HK/US stocks, funds, and portfolios.
- It includes a scheduled GitHub Actions agent example for daily recaps: https://github.com/AdvancingTitans/stock-analysis/blob/main/examples/github-actions-daily-recap.yml

## Affiliation disclosure

Affiliated: submitting from the AdvancingTitans account that maintains stock-analysis.
