### PR TITLE
Add BDE Score™ - AI-Powered Multi-Market Stock Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Price and Volume process with Technology Analysis Indices
 - [alphalens](https://github.com/quantopian/alphalens) - Performance analysis of predictive (alpha) stock factors.
 - [empyrical](https://github.com/quantopian/empyrical) - Common financial risk and performance metrics. Used by Zipline and pyfolio.
 - [zvt](https://github.com/zvtvz/zvt) - Zero vector trader.
+
+- [BDE Score](https://github.com/hbhqq9/bde-score) - AI-powered multi-market stock analysis with transparent BDE scoring across 73 stocks (US/HK/A-share). EU AI Act Art.50 compliant. MIT license.
 - [CongressionalStockBrain](https://congressionalstockbrain.com) - AI-powered tool that ingests U.S. STOCK Act congressional trade disclosures and converts them into machine-scored signals for retail investors.
 - [WalletLens](https://walletlens.live) - Multi-asset portfolio tracker with AI insights, technical analysis, live prices, and local-first data storage.
 - [WFGY](https://github.com/onestardao/WFGY) – Open source framework for debugging and stress testing LLM agents and RAG pipelines. Includes a 16 mode failure map and long-horizon stress tests that are useful for financial research agents.


### PR DESCRIPTION
## Add BDE Score™ to Technical Analysis section

Adding [BDE Score™](https://github.com/hbhqq9/bde-score) to the **Technical Analysis** section under **Strategies & Research**.

### About BDE Score™
- **AI-Powered Multi-Market Stock Analysis** — transparent multi-factor scoring for 73 stocks across US, HK, and A-share markets
- **EU AI Act Art.50 compliant**
- **Live Demo**: https://rebel-north-intermediate-roof.trycloudflare.com
- **License**: MIT
- **Topics**: stock-analysis, quantitative-finance, ai-finance, eu-ai-act, multi-market

Thank you for maintaining this awesome list! 🙏