### PR TITLE
Add NeuPortal to Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Price and Volume process with Technology Analysis Indices
 - [CRNG](https://github.com/brotto/crng) - Contingency RNG, generates random numbers with real market fat tails (K=5-220) and volatility clustering. Matches 86% of real market metrics vs 14% for NumPy. Includes regime detector.
 - [Chart Library](https://chartlibrary.io) - Visual chart pattern search engine. Upload a screenshot or type a ticker+date to find the 10 most similar historical chart patterns and see what happened next. 24M+ embeddings, 19K symbols, REST API + MCP server.
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action & volume spikes dashboard for crypto traders. Free, no sign-up required.
+- [NeuPortal](https://neuportal.ai) - AI forecasting-accountability lab: every forecast is locked pre-event, Bitcoin-timestamped (OpenTimestamps), and Brier-scored against prediction markets in public.
 
 ## Trading System
 


### PR DESCRIPTION
Adds **NeuPortal** to the Research Tools section.

NeuPortal is an AI forecasting-accountability lab: every forecast is locked pre-event, Bitcoin-timestamped (OpenTimestamps), and Brier-scored against prediction markets in public. Fits alongside the evaluation/analytics tools in this section.

- Site: https://neuportal.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)