### PR TITLE
Add ml-quant-trading to portfolio management

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Price and Volume process with Technology Analysis Indices
 - [qtrader](https://github.com/filangel/qtrader) - Reinforcement Learning for portfolio management.
 - [PGPortfolio](https://github.com/ZhengyaoJiang/PGPortfolio) - A Deep Reinforcement Learning framework for the financial portfolio management problem.
 - [DeepDow](https://github.com/jankrepl/deepdow) - Portfolio optimization with deep learning.
+- [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) - PyTorch research stack for mask-aware multi-factor modeling, ML baselines, portfolio optimization, and vectorized backtesting.
 - [skfolio](https://github.com/skfolio/skfolio) - Python library for portfolio optimization built on top of scikit-learn.
 
 ### High Frequency Trading


### PR DESCRIPTION
## What changed

Adds `ml-quant-trading` to Strategies & Research → Portfolio Management using the existing one-line format.

## Why it fits

The project is an MIT-licensed PyTorch research stack for mask-aware multi-factor modeling, ML baselines, portfolio optimization, and vectorized backtesting. Its accompanying arXiv paper documents the factor-to-portfolio workflow and the handling of non-tradable A-share observations.

## Impact

Readers gain another open-source, research-oriented portfolio workflow. The entry is concise and makes no profitability or live-trading claims.

## Validation

- Confirmed the project is not already listed.
- Matched the existing section and Markdown format.
- Ran `git diff --check` and verified the repository link.

## Disclosure

I maintain `initial-d/ml-quant-trading` and authored its accompanying paper; this is a transparent self-submission.
