### PR TITLE
Add DDScore to Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Price and Volume process with Technology Analysis Indices
 
 ## Research Tools
 
+- [DDScore](https://www.ddscore.ai/for-investor/) - AI-assisted first-pass due diligence for private-company materials, producing a structured 0–100 score and written report across 12 dimensions while checking relevant claims against current public sources. Supports analyst judgement; not investment advice or a replacement for full due diligence.
 - [Synthical](https://synthical.com) - AI-powered collaborative environment for Research.
 - 🌟🌟 [TensorTrade](https://github.com/tensortrade-org/tensortrade) - Trade efficiently with reinforcement learning.
 - [ML-Quant](https://www.ml-quant.com/) - Quant resources from ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.


### PR DESCRIPTION
Adds DDScore to the Research Tools section as a private-company first-pass diligence resource:

- [DDScore](https://www.ddscore.ai/for-investor/) - AI-assisted first-pass due diligence for private-company materials, producing a structured 0–100 score and written report across 12 dimensions while checking relevant claims against current public sources. Supports analyst judgement; not investment advice or a replacement for full due diligence.

I work on DDScore at Playful Pixels Oy and am submitting this openly as the maker. The entry is one line, uses the existing list format, and links to the investor-specific product page.