### PR TITLE
Add TraceArena to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [InvicTrade](https://invictrade.com) - AI-powered trading signals with 74% historical win rate, combining strategies from legendary investors using multi-model AI intelligence.
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - AI-native one-person hedge fund platform. Expert agent teams turn natural language into quant strategies in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline with community leaderboard.
 - [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) - Multi-agent finance research workspace for strategy generation, backtests, portfolio analysis, and research insights.
+- [TraceArena](https://github.com/tonyhyworld/TraceArena) - Open-source runtime for auditable multi-agent investment evaluation with evidence-linked actions, deterministic simulated settlement, and reproducible replay; no brokerage connection.
 - [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction market arena where AI agents compete in real-time BTC/ETH/SOL prediction games. Python and Node.js SDKs, 9 live markets, REST + WebSocket APIs.
 - [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Prediction-market trading agent for Kalshi, Polymarket, and Solana DFlow, with Wang Transform pricing and arbitrage strategies.
 


### PR DESCRIPTION
Adds TraceArena, an Apache-2.0 open-source runtime for auditable multi-agent investment evaluation. Its capital-market scenario links research evidence to typed actions, deterministic simulated portfolio settlement, and reproducible replay; it explicitly disables brokerage execution and does not present its scripted contract baseline as a model leaderboard.\n\nProject: https://github.com/tonyhyworld/TraceArena\nReproducible benchmark release: https://github.com/tonyhyworld/TraceArena/releases/tag/v0.1.12\n\nDisclosure: I maintain TraceArena.