### PR TITLE
Add QuantLink to Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Price and Volume process with Technology Analysis Indices
 - [CRNG](https://github.com/brotto/crng) - Contingency RNG, generates random numbers with real market fat tails (K=5-220) and volatility clustering. Matches 86% of real market metrics vs 14% for NumPy. Includes regime detector.
 - [Chart Library](https://chartlibrary.io) - Visual chart pattern search engine. Upload a screenshot or type a ticker+date to find the 10 most similar historical chart patterns and see what happened next. 24M+ embeddings, 19K symbols, REST API + MCP server.
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action & volume spikes dashboard for crypto traders. Free, no sign-up required.
+- [QuantLink](https://www.quantlink.ai) - AI-powered US-equity research terminal with deep-research agents grounded in SEC filings, a fundamental and technical stock screener with backtesting, institutional 13F holder analysis, insider (Form 4) activity, and congressional trade tracking from STOCK Act disclosures. Free tier available.
 
 ## Trading System
 


### PR DESCRIPTION
Adds one entry for **QuantLink** (https://www.quantlink.ai) to the **Research Tools** section.

QuantLink is an AI-powered US-equity research terminal: deep-research agents grounded in SEC filings, a fundamental and technical stock screener with backtesting, institutional 13F holder analysis, insider (Form 4) activity, and congressional trade tracking from STOCK Act disclosures. Free tier available.

It fits Research Tools alongside existing entries like CongressionalStockBrain, WalletLens, and Synthical (AI-assisted research surfaces rather than trading bots).

- One entry, added at the end of the section, format matches surrounding entries.
- Not a duplicate.
- Website is live and https.

Made with [Cursor](https://cursor.com)