### PR TITLE
Add DepthFeed prediction-market liquidity benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Price and Volume process with Technology Analysis Indices
 
 #### Prediction Markets
 
+- [DepthFeed Prediction Market Liquidity Benchmark](https://depthfeed.com/arena/liquidity) - Open 34,560-observation order-book dataset and reproducible study of BTC 15-minute markets across Polymarket, Kalshi, Predict.fun via Binance Wallet, and Limitless. [GitHub](https://github.com/vcorp-dev/prediction-market-liquidity-benchmark)
 - [Parsec API](https://docs.parsecapi.com) - Unified prediction market infrastructure for normalized data, execution, and live streams across Polymarket, Kalshi, Opinion, Limitless, and PredictFun. MCP server for AI agent trading. Generous free tier.
 - [PolyMind](https://polyminds.netlify.app/) - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available.
 


### PR DESCRIPTION
## Summary

Adds the DepthFeed Prediction Market Liquidity Benchmark under Data Sources → Prediction Markets.

## Why it fits

The v2.0.0 release is an open, reproducible dataset for quantitative research and ML workflows:

- 34,560 lifecycle-aligned order-book observations from BTC 15-minute markets;
- Polymarket, Kalshi, Predict.fun via Binance Wallet, and Limitless coverage;
- public row-level CSV, summary CSV, and JSON artifacts;
- documented methodology, limitations, checksum, citation metadata, and a dependency-free verifier;
- CC BY 4.0 data/research license and MIT code license.

I searched the README and open/closed pull requests and found no existing DepthFeed entry. The canonical report and public repository both return HTTP 200, and `git diff --check` passes.

Affiliation disclosure: I am submitting this on behalf of the DepthFeed team.
