### PR TITLE
Add EarningsCall - Earnings Call Transcript API for Traditional Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Price and Volume process with Technology Analysis Indices
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 - [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with classified 8-Ks, activist 13D/G tagging, ATM offering detection, and hosted MCP access.
-
+- [EarningsCall](https://earningscall.biz) - REST API and Python/JavaScript SDK for earnings call transcripts, audio files, and slide decks for 9,000+ public companies. Speaker-level data with Q&A segmentation. Transcripts available within 15 minutes of each call ending.
 #### Crypto Currencies
 
 - [BitBank.nz](https://bitbank.nz) - AI-powered crypto forecasting and predictions API with machine learning models for 70+ cryptocurrency pairs.


### PR DESCRIPTION
EarningsCall provides a production-ready REST API and official Python and JavaScript SDKs for accessing earnings call transcripts, audio files, slide decks, and earnings calendar data for 9,000+ publicly traded companies across NYSE, NASDAQ, and global exchanges.

This is a valuable data source for AI and LLM applications in finance, particularly for:

Building NLP pipelines and sentiment analysis models on earnings call data Fine-tuning LLMs with high-quality financial speech data Event-driven trading strategies based on earnings call content Quantitative research using speaker-level transcript data

Key features:

Speaker-level transcript data with Q&A segmentation Transcripts available within 15 minutes of each call ending Raw MP3/WAV audio files for every covered earnings call Investor presentation slide decks
Earnings event calendar API
Real-time webhook notifications
Plans start at $60/month

GitHub: https://github.com/EarningsCall/earningscall-python