### PR TITLE
Add DAUDIT to Others — decision audit tool for investment decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ Do it in real world!
 - [Using LSTMs to Turn Feelings Into Trades](https://www.quantopian.com/posts/watch-our-webinar-buying-happiness-using-lstms-to-turn-feelings-into-trades-now?utm_source=forum&utm_medium=twitter&utm_campaign=sentiment-analysis)
 
 ## Others
+- [DAUDIT](https://www.daudit.net) - Decision-context engine that audits investment and business decisions across five dimensions (World Model Gaps, Adversarial Risk, Theory of Mind, Decision State, Confidence vs Evidence) before you commit to irreversible decisions.
+
 
 - [zipline-tensorboard](https://github.com/jimgoo/zipline-tensorboard) - TensorBoard as a Zipline dashboard.
 - [gekko-quasar-ui](https://github.com/H256/gekko-quasar-ui) - An UI port for gekko trading bot using Quasar framework.


### PR DESCRIPTION
## What

Adding [DAUDIT](https://www.daudit.net) to the Others section.

## Why

DAUDIT is a decision-context engine that audits high-stakes decisions across five dimensions before you commit. While not specifically a finance tool, it is highly relevant to investment decisions — investors face irreversible choices (fund allocation, portfolio crises, entry/exit timing) and DAUDIT provides structured analysis to improve decision quality.

The five dimensions (World Model Gaps, Adversarial Risk, Theory of Mind, Decision State, Confidence vs Evidence) are particularly relevant for investment decisions where hidden risks and overconfidence are common failure modes.

## Format

Follows the existing bullet list format.