### PR TITLE
Add Jacobian to AI finance research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Price and Volume process with Technology Analysis Indices
 
 - [DDScore](https://www.ddscore.ai/for-investor/) - AI-assisted first-pass due diligence for private-company materials, producing a structured 0–100 score and written report across 12 dimensions while checking relevant claims against current public sources. Supports analyst judgement; not investment advice or a replacement for full due diligence.
 - [Synthical](https://synthical.com) - AI-powered collaborative environment for Research.
+- [morluto/jacobian](https://github.com/morluto/jacobian) - MCP server, CLI, and Python library for composable mathematics: exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.
 - 🌟🌟 [TensorTrade](https://github.com/tensortrade-org/tensortrade) - Trade efficiently with reinforcement learning.
 - [ML-Quant](https://www.ml-quant.com/) - Quant resources from ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 - [JAQS](https://github.com/quantOS-org/JAQS) - An open source quant strategies research platform.


### PR DESCRIPTION
Adds Jacobian to Research Tools. One README entry added; nothing else changed.

What it is: an MCP server, CLI, and Python library for composable mathematics: exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.

Why it fits: Jacobian provides exact, runnable mathematical operations that can support reproducible research experiments alongside the financial research and analysis tools in this list. It is listed as research infrastructure, not as a trading or market-data system.

Validation:
- `git diff --check`

