### PR TITLE
Add Bargo Congress API skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 
 ## Skills
 
+- [Bargo Congress API](https://github.com/bargo-ai/bargo-free-api-packages/tree/main/skills/bargo-congress-api) - Agent skill for querying normalized U.S. House and Senate STOCK Act transaction disclosures by ticker, member, chamber, transaction type, and date.
 - [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
 - [CFA Institute Bias Detection](https://github.com/CFA-Institute-RPC/skills/tree/main/skills/bias-detection) - Claude skill for bias detection in investment analysis. Apache 2.0.
 - [Ethical Capital Skills](https://github.com/ethicalcapital/skills) - Claude skills for investment research, screening, compliance, and marketing workflows.


### PR DESCRIPTION
Adds the open-source Bargo Congress API agent skill to the Skills section.

It helps agents query normalized House and Senate STOCK Act disclosures by ticker, member, chamber, transaction type, and date. The source is public, the skill is indexed on skills.sh, and the API has a free tier.

Disclosure: I maintain Bargo and the linked repository.
