### PR TITLE
add ai-agent-playbook: AI Agent × quant finance knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [Cod3x](https://www.cod3x.org/) - No-code platform for building multi-agent trading strategies, with chart-drawing agents, event-driven automations, and full execution transparency.
 
 - [Pineify](https://pineify.app/) - AI-assisted trading toolkit with coding agents for Pine Script, MQL5, and cTrader, plus financial research, strategy optimization, and backtest analysis.
+- 🌟 [ai-agent-playbook](https://github.com/Electricitysheep/ai-agent-playbook) - AI Agent engineering x quantitative finance knowledge base: 106 evidence-graded notes (source-level agent architecture, A2A protocol, LLM factor mining) + 16 runnable code experiments.
 
 ## LLMs
 


### PR DESCRIPTION
## What
Add [ai-agent-playbook](https://github.com/Electricitysheep/ai-agent-playbook) to the Agents section.

## Why
ai-agent-playbook is an AI Agent engineering × quantitative finance knowledge base with:
- 106 evidence-graded original notes (each marked with source tier: official docs / community reverse-engineering / local empirical testing)
- Source-level agent architecture analysis (Claude Code Agent Teams, Devin, omp hub IPC)
- A2A protocol research (14-agent comparison matrix)
- 16 runnable code experiments (LLM factor mining, walk-forward validation, production risk-control simulator)
- Obsidian vault, clone-and-use

Perfect fit for the **Agents** section of this list (AI × financial market).