### PR TITLE
docs: add AI Trader Team to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [CFA Institute Bias Detection](https://github.com/CFA-Institute-RPC/skills/tree/main/skills/bias-detection) - Claude skill for bias detection in investment analysis. Apache 2.0.
 - [Ethical Capital Skills](https://github.com/ethicalcapital/skills) - Claude skills for investment research, screening, compliance, and marketing workflows.
 - [Trading Ledger](https://github.com/cruisekkk/trading-ledger) - Claude skill for trading journaling: captures thesis, plan, and emotion at entry into the user's own Notion database, with weekly reviews that grade decisions rather than P&L. MIT.
+- [AI Trader Team](https://github.com/TLSRUF/ai-trader-team) - Claude Code framework combining slash-command skills, parallel perspective sub-agents (trend/macro/risk/flow), and deterministic Decimal-based verification tools (position sizing, portfolio heat, walk-forward backtesting) for personal investment research. MIT.
 
 ## MCP Servers
 


### PR DESCRIPTION
Adding [AI Trader Team](https://github.com/TLSRUF/ai-trader-team) to the **Skills** section, alongside the other Claude Code skill projects already listed there.

**What it is**: a Claude Code framework for personal investment research — slash-command skills (`/screen`, `/trade-team`, `/position-review`, `/portfolio`, `/post-mortem`) trigger parallel perspective sub-agents (trend/macro/risk/flow analysts) that debate rather than converge on a single answer, backed by deterministic Decimal-based tools for position sizing, portfolio heat, risk/reward, and walk-forward backtesting (so LLM narrative and arithmetic are never mixed).

- MIT licensed, open source
- Single-line addition only, no other entries touched
- Fits the existing Skills section format/tone