### PR TITLE
Add Edgrapi to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Price and Volume process with Technology Analysis Indices
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [BenchGecko](https://benchgecko.ai) - AI economy tracking platform. Market cap, funding rounds, AI Bubble Index, company valuations, and compute supply chain data.
 - [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with classified 8-Ks, activist 13D/G tagging, ATM offering detection, and hosted MCP access.
+- [Edgrapi](https://edgrapi.com) - SEC EDGAR filings as clean JSON: Form 4 insider trades with cluster-buy detection, 8-K events, 13F holdings aggregated by CUSIP and diffed quarter-over-quarter, 13D/13G >5% stakes, XBRL fundamentals and full-text search. REST API plus a hosted MCP server, free tier.
 
 #### Crypto Currencies
 


### PR DESCRIPTION
SEC EDGAR data API and hosted MCP server: Form 4 insider trades with cluster-buy detection, typed 8-K events, 13F fund holdings diffed quarter-over-quarter, 13D/13G >5% stakes, XBRL fundamentals and full-text search since 2001. Listed on the official MCP registry. Free tier, no card.