### PR TITLE
Add Nova-TradingAgent under Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 
 - 🌟🌟 [nofx](https://github.com/NoFxAiOS/nofx) - A multi-exchange Al trading platform with multi-Ai competition self-evolution, and real-time dashboard.
 - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - Multi-Agents LLM Financial Trading Framework.
+- [Nova-TradingAgent](https://github.com/rufeng0411/Nova-TradingAgent) - Self-hosted A-share research desk: TradingAgents graph as a login Web UI (15 agents). Does not place trades. AGPL-3.0.
 - 🌟 [FinRobot](https://github.com/AI4Finance-Foundation/FinRobot) - An Open-Source AI Agent Platform for Financial Analysis using LLMs.
 - [AgentFund](https://github.com/RioBot-Grind/agentfund) - Decentralized crowdfunding platform for AI agents with milestone-based escrow on Base blockchain.
 - 🌟 [ATLAS](https://github.com/chrisworsey55/atlas-gic) - Self-improving AI trading system with 25 agents, Karpathy-style autoresearch, Darwinian selection, autonomous agent spawning, and multi-cohort meta-weighting.


### PR DESCRIPTION
Add Nova-TradingAgent under Agents, next to TradingAgents.

Self-hosted A-share research desk wrapping the TradingAgents multi-agent graph as a login Web UI. Does not place trades. AGPL-3.0.

Repo: https://github.com/rufeng0411/Nova-TradingAgent
