### PR TITLE
Add Market Brief to financial research skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 
 ## Skills
 
+- [Market Brief](https://github.com/beepboop2025/market-brief) - Agent skill for source-linked funding, capital-market, and liquidity briefs, with local Python comparisons that preserve observation dates and missing-data states. MIT.
 - [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
 - [CFA Institute Bias Detection](https://github.com/CFA-Institute-RPC/skills/tree/main/skills/bias-detection) - Claude skill for bias detection in investment analysis. Apache 2.0.
 - [Ethical Capital Skills](https://github.com/ethicalcapital/skills) - Claude skills for investment research, screening, compliance, and marketing workflows.


### PR DESCRIPTION
Adds **Market Brief** to **Skills**: an MIT-licensed agent skill for source-linked funding, capital-market, and liquidity research briefs, with local comparisons between saved snapshots.

The skill uses a standard-library Python helper to project selected public observations, preserve source dates and unavailable-data states, and distinguish value/state changes from retrieval-only timestamp updates. Compatible AI assistants can use it with the documented skill instructions. The repository also includes a free browser app; this entry describes the financial research skill rather than a new hosted MCP server or trading-execution service.

- [Source and runnable examples](https://github.com/beepboop2025/market-brief)
- [Versioned skill instructions](https://github.com/beepboop2025/market-brief/blob/v0.1.0/skills/market-brief/SKILL.md)
- [v0.1.0 release](https://github.com/beepboop2025/market-brief/releases/tag/v0.1.0)

Validation: ran the documented Python command from a fresh v0.1.0 checkout on September 6, 2026; it completed successfully with a source-linked brief. `git diff --check` passed. Checked both README catalogs and open/closed pull requests for the project name and repository URL; no duplicate was found.

**Relationship disclosure:** Maintainer submission from the GitHub account that owns Market Brief; the publisher is Liquidity Lab. The code is MIT licensed, and the browser app is free during early access, subject to public upstream data availability.
