### PR TITLE
Add Quant Research to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [CFA Institute Bias Detection](https://github.com/CFA-Institute-RPC/skills/tree/main/skills/bias-detection) - Claude skill for bias detection in investment analysis. Apache 2.0.
 - [Ethical Capital Skills](https://github.com/ethicalcapital/skills) - Claude skills for investment research, screening, compliance, and marketing workflows.
 - [Trading Ledger](https://github.com/cruisekkk/trading-ledger) - Claude skill for trading journaling: captures thesis, plan, and emotion at entry into the user's own Notion database, with weekly reviews that grade decisions rather than P&L. MIT.
+- [Quant Research](https://github.com/Jimmy7892/quant-research-skill) - Claude skill for validating a backtest: map the parameter surface, bound a stable region instead of picking the argmax, correct for selection bias, then walk-forward. Engine-agnostic. MIT.
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ With the power of the latest artificial intelligence research, people analyze & 
 - [CFA Institute Bias Detection](https://github.com/CFA-Institute-RPC/skills/tree/main/skills/bias-detection) - Claude skill for bias detection in investment analysis. Apache 2.0.
 - [Ethical Capital Skills](https://github.com/ethicalcapital/skills) - Claude skills for investment research, screening, compliance, and marketing workflows.
 - [Trading Ledger](https://github.com/cruisekkk/trading-ledger) - Claude skill for trading journaling: captures thesis, plan, and emotion at entry into the user's own Notion database, with weekly reviews that grade decisions rather than P&L. MIT.
-- [Quant Research](https://github.com/Jimmy7892/quant-research-skill) - Claude skill for validating a backtest: map the parameter surface, bound a stable region instead of picking the argmax, correct for selection bias, then walk-forward. Engine-agnostic. MIT.
+- [Quant Research](https://github.com/Jimmy7892/quant-research-skill) - Agent skill for backtest validation using parameter stability, selection-bias checks, and walk-forward evaluation.
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds one entry to `## Skills`.

The four skills currently listed cover research, screening, bias detection and journaling. None of them covers the step between a backtest and a decision: deciding whether a result is real. That is what this one does.

It encodes a single rule, applied through five gates: never trade the argmax of a parameter sweep. Map the surface, bound the region that stays profitable within one standard error, pool it, then check it survives walk-forward and a selection-bias correction sized to the number of independent selections actually made.

It is engine-agnostic. The method applies to any backtester, and the skill helps a user who runs a different one; only one of its seven reference files is specific to a single engine.

MIT licensed. Disclosure: I wrote the skill, and I am also the author of the backtesting engine named in that one reference file. The skill deliberately makes no comparison with other engines.
